### PR TITLE
Add EventoOrdenServicio entity and DB script

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -50,6 +50,7 @@ namespace MultiservicioB.Data
             builder.Entity<ConsumoMaterial>().ToTable("ConsumoMaterial");
             builder.Entity<Notificacion>().ToTable("Notificaciones");
             builder.Entity<FotoOrdenServicio>().ToTable("FotoOrden");
+            builder.Entity<EventoOrdenServicio>().ToTable("EventoOrdenServicio");
 
             builder.Entity<Empleado>()
                 .HasOne(e => e.User)

--- a/Models/EventoOrdenServicio.cs
+++ b/Models/EventoOrdenServicio.cs
@@ -7,6 +7,7 @@ namespace MultiservicioB.Models
     /// <summary>
     /// Representa el registro de eventos y observaciones de una orden de servicio (RT-001, RT-002, RT-003, RT-006, RT-007)
     /// </summary>
+    [Table("EventoOrdenServicio")]
     public class EventoOrdenServicio : BaseModel
     {
         [Key]

--- a/Models/FotoOrdenServicio.cs
+++ b/Models/FotoOrdenServicio.cs
@@ -7,6 +7,7 @@ namespace MultiservicioB.Models
     /// <summary>
     /// Representa las evidencias fotográficas de una orden de servicio (RT-004)
     /// </summary>
+    [Table("FotoOrden")]
     public class FotoOrdenServicio : BaseModel
     {
         [Key]

--- a/Scripts de Base de datos/crear_tabla_eventoorden_si_falta.sql
+++ b/Scripts de Base de datos/crear_tabla_eventoorden_si_falta.sql
@@ -1,0 +1,58 @@
+/*
+    Crea la tabla usada por ordenes de servicio para eventos RT.
+    Es idempotente: si ya existe, no duplica nada.
+*/
+
+IF OBJECT_ID(N'dbo.EventoOrdenServicio', N'U') IS NULL
+BEGIN
+    IF OBJECT_ID(N'dbo.EventosOrdenServicio', N'U') IS NOT NULL
+    BEGIN
+        EXEC sp_rename N'dbo.EventosOrdenServicio', N'EventoOrdenServicio';
+    END
+    ELSE
+    BEGIN
+        CREATE TABLE [dbo].[EventoOrdenServicio] (
+            [IdEvento]    INT             IDENTITY (1, 1) NOT NULL,
+            [OrdenId]     INT             NOT NULL,
+            [TipoEvento]  NVARCHAR (50)   NOT NULL,
+            [FechaEvento] DATETIME        CONSTRAINT [DF_EventoOrdenServicio_FechaEvento] DEFAULT (GETDATE()) NOT NULL,
+            [Descripcion] NVARCHAR (1000) NULL,
+            [Latitud]     DECIMAL (10, 7) NULL,
+            [Longitud]    DECIMAL (10, 7) NULL,
+            [UsuarioId]   NVARCHAR (450)  NULL,
+            CONSTRAINT [PK_EventoOrdenServicio] PRIMARY KEY CLUSTERED ([IdEvento] ASC),
+            CONSTRAINT [CK_EventoOrdenServicio_TipoEvento] CHECK (
+                [TipoEvento] = N'AceptacionCliente' OR
+                [TipoEvento] = N'ComentarioFinal' OR
+                [TipoEvento] = N'FinalizacionServicio' OR
+                [TipoEvento] = N'ObservacionTecnica' OR
+                [TipoEvento] = N'InicioServicio' OR
+                [TipoEvento] = N'LlegadaSitio'
+            )
+        );
+    END
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_EventoOrdenServicio_OrdenId'
+      AND object_id = OBJECT_ID(N'dbo.EventoOrdenServicio')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_EventoOrdenServicio_OrdenId]
+        ON [dbo].[EventoOrdenServicio]([OrdenId] ASC);
+END;
+
+IF OBJECT_ID(N'dbo.OrdenesServicio', N'U') IS NOT NULL
+   AND NOT EXISTS (
+        SELECT 1
+        FROM sys.foreign_keys
+        WHERE name = N'FK_EventoOrdenServicio_OrdenesServicio_OrdenId'
+   )
+BEGIN
+    ALTER TABLE [dbo].[EventoOrdenServicio] WITH CHECK
+    ADD CONSTRAINT [FK_EventoOrdenServicio_OrdenesServicio_OrdenId]
+        FOREIGN KEY ([OrdenId]) REFERENCES [dbo].[OrdenesServicio] ([IdOrden])
+        ON DELETE CASCADE;
+END;

--- a/Services/OrdenServicioService.cs
+++ b/Services/OrdenServicioService.cs
@@ -237,6 +237,8 @@ namespace MultiservicioB.Services
 
         public async Task<bool> ConfirmarLlegadaSitioAsync(int id, decimal latitud, decimal longitud)
         {
+            await AsegurarTablaEventoOrdenAsync();
+
             var orden = await _context.OrdenesServicio.FindAsync(id);
             if (orden == null) return false;
 
@@ -261,6 +263,8 @@ namespace MultiservicioB.Services
 
         public async Task<bool> IniciarOrdenAsync(int id)
         {
+            await AsegurarTablaEventoOrdenAsync();
+
             var orden = await _context.OrdenesServicio.FindAsync(id);
             if (orden == null || !orden.EmpleadoId.HasValue) return false;
 
@@ -290,6 +294,8 @@ namespace MultiservicioB.Services
 
         public async Task<bool> FinalizarOrdenAsync(int id, string comentariosFinales)
         {
+            await AsegurarTablaEventoOrdenAsync();
+
             var orden = await _context.OrdenesServicio.FindAsync(id);
             if (orden == null) return false;
 
@@ -330,6 +336,8 @@ namespace MultiservicioB.Services
 
         public async Task<bool> AceptarFinalizacionClienteAsync(int id)
         {
+            await AsegurarTablaEventoOrdenAsync();
+
             var orden = await _context.OrdenesServicio.FindAsync(id);
             if (orden == null) return false;
 
@@ -357,6 +365,8 @@ namespace MultiservicioB.Services
 
         public async Task<bool> ActualizarObservacionesTecnicasAsync(int id, string observaciones)
         {
+            await AsegurarTablaEventoOrdenAsync();
+
             var orden = await _context.OrdenesServicio.FindAsync(id);
             if (orden == null) return false;
 
@@ -426,6 +436,52 @@ namespace MultiservicioB.Services
             return string.IsNullOrWhiteSpace(direccionTexto)
                 ? null
                 : $"https://www.google.com/maps/search/?api=1&query={Uri.EscapeDataString(direccionTexto)}";
+        }
+
+        private async Task AsegurarTablaEventoOrdenAsync()
+        {
+            await _context.Database.ExecuteSqlRawAsync("""
+                IF OBJECT_ID(N'dbo.EventoOrdenServicio', N'U') IS NULL
+                BEGIN
+                    IF OBJECT_ID(N'dbo.EventosOrdenServicio', N'U') IS NOT NULL
+                    BEGIN
+                        EXEC sp_rename N'dbo.EventosOrdenServicio', N'EventoOrdenServicio';
+                    END
+                    ELSE
+                    BEGIN
+                        CREATE TABLE [dbo].[EventoOrdenServicio] (
+                            [IdEvento]    INT             IDENTITY (1, 1) NOT NULL,
+                            [OrdenId]     INT             NOT NULL,
+                            [TipoEvento]  NVARCHAR (50)   NOT NULL,
+                            [FechaEvento] DATETIME        CONSTRAINT [DF_EventoOrdenServicio_FechaEvento] DEFAULT (GETDATE()) NOT NULL,
+                            [Descripcion] NVARCHAR (1000) NULL,
+                            [Latitud]     DECIMAL (10, 7) NULL,
+                            [Longitud]    DECIMAL (10, 7) NULL,
+                            [UsuarioId]   NVARCHAR (450)  NULL,
+                            CONSTRAINT [PK_EventoOrdenServicio] PRIMARY KEY CLUSTERED ([IdEvento] ASC),
+                            CONSTRAINT [CK_EventoOrdenServicio_TipoEvento] CHECK (
+                                [TipoEvento] = N'AceptacionCliente' OR
+                                [TipoEvento] = N'ComentarioFinal' OR
+                                [TipoEvento] = N'FinalizacionServicio' OR
+                                [TipoEvento] = N'ObservacionTecnica' OR
+                                [TipoEvento] = N'InicioServicio' OR
+                                [TipoEvento] = N'LlegadaSitio'
+                            )
+                        );
+                    END
+                END
+
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.indexes
+                    WHERE name = N'IX_EventoOrdenServicio_OrdenId'
+                      AND object_id = OBJECT_ID(N'dbo.EventoOrdenServicio')
+                )
+                BEGIN
+                    CREATE NONCLUSTERED INDEX [IX_EventoOrdenServicio_OrdenId]
+                        ON [dbo].[EventoOrdenServicio]([OrdenId] ASC);
+                END
+                """);
         }
 
         public async Task<int> CalcularTiempoEfectivoAsync(int id)


### PR DESCRIPTION
Register EventoOrdenServicio in DbContext and add [Table] attributes for EventoOrdenServicio and FotoOrden. Add an idempotent SQL script (Scripts de Base de datos/crear_tabla_eventoorden_si_falta.sql) that creates/renames the table, index and FK if missing. Implement runtime fallback AsegurarTablaEventoOrdenAsync in OrdenServicioService and call it from methods that record events (llegada, inicio, finalización, aceptación y observaciones) to avoid failures when the DB table is absent. Handles legacy EventosOrdenServicio rename and creates IX_EventoOrdenServicio_OrdenId.